### PR TITLE
Fixed error handling for 404 errors and added support for thumbnails.

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -66,16 +66,21 @@ YoutubeMp3Downloader.prototype.download = function(videoId, fileName) {
 
 };
 
-YoutubeMp3Downloader.prototype.performDownload = function(task, cb) {
+YoutubeMp3Downloader.prototype.performDownload = function(task, callback) {
 
     var self = this;
     var videoUrl = self.youtubeBaseUrl+task.videoId;
 
     ytdl.getInfo(videoUrl, function(err, info){
+        if (err) {
+          callback(err.message);
+          return;
+        }
 
         var videoTitle = self.cleanFileName(info.title);
         var artist = "Unknown";
         var title = "Unknown";
+        var thumbnail = info.iurlhq;
 
         if (videoTitle.indexOf("-") > -1) {
             var temp = videoTitle.split("-");
@@ -130,7 +135,7 @@ YoutubeMp3Downloader.prototype.performDownload = function(task, cb) {
                 .outputOptions('-metadata', 'title=' + title)
                 .outputOptions('-metadata', 'artist=' + artist)
                 .on('error', function(err) {
-                    cb(err.message, null);
+                    callback(err.message, null);
                 })
                 .on('end', function() {
                     resultObj.file =  fileName;
@@ -139,7 +144,8 @@ YoutubeMp3Downloader.prototype.performDownload = function(task, cb) {
                     resultObj.videoTitle = videoTitle;
                     resultObj.artist = artist;
                     resultObj.title = title;
-                    cb(null, resultObj);
+                    resultObj.thumbnail = thumbnail;
+                    callback(null, resultObj);
                 })
                 .saveToFile(fileName);
 


### PR DESCRIPTION
Previously, the application would crash if the library was asked to download an invalid id. While ids could be validated outside of the library, it would require another instance of `ytdl` which means (on average) another request to Youtube (if the id is valid). As such, handling id validation within the library is the most efficient way to do this, minimizing the amount of code needed outside of the library and the number of requests made to Youtube.

I also added the URL to a video's thumbnail in the `resultObj`, in case the client wants to store the information and display it later on. While one could argue this is easy enough to generate and should not be returned, so is the `videoUrl`. Returning it also protects against YouTube changing its thumbnail path, which would otherwise break hard-coded URLs. 
