### PR TITLE
Fixed invalid filenames 

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -6,6 +6,7 @@ var ffmpeg = require("fluent-ffmpeg");
 var ytdl = require("ytdl-core");
 var async = require("async");
 var progress = require("progress-stream");
+var sanitize = require("sanitize-filename");
 
 function YoutubeMp3Downloader(options) {
 
@@ -99,7 +100,7 @@ YoutubeMp3Downloader.prototype.performDownload = function(task, callback) {
             }
 
             //Derive file name, if given, use it, if not, from video title
-            var fileName = (task.fileName ? self.outputPath + "/" + task.fileName : self.outputPath + "/" + videoTitle + ".mp3");
+            var fileName = (task.fileName ? self.outputPath + "/" + task.fileName : self.outputPath + "/" + (sanitize(videoTitle) || info.video_id) + ".mp3");
 
             ytdl.getInfo(videoUrl, { quality: self.youtubeVideoQuality }, function(err, info) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-mp3-downloader",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -97,6 +97,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "requires": {
+        "truncate-utf8-bytes": "1.0.2"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -123,6 +131,19 @@
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       }
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "1.0.4"
+      }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "async": "^2.6.0",
     "fluent-ffmpeg": "2.1.2",
     "progress-stream": "^2.0.0",
+    "sanitize-filename": "^1.6.1",
     "ytdl-core": "^0.20.1"
   },
   "author": {


### PR DESCRIPTION
Hi,

i had this error:
If the videotitle had an invalid character like `|` in it ffmpeg would exit with `Invalid argument`.

So i added [sanitize-filename](https://www.npmjs.com/package/sanitize-filename) to "sanitize" the filename or if its completely invalid to use the video id for the filename.


