### PR TITLE
Fixed problem with video Names that contain "|"

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -17,7 +17,7 @@ function YoutubeMp3Downloader(options) {
     self.outputPath = (options && options.outputPath ? options.outputPath : (os.platform() === "win32" ? "C:/Windows/Temp" : "/tmp"));
     self.queueParallelism = (options && options.queueParallelism ? options.queueParallelism : 1);
     self.progressTimeout = (options && options.progressTimeout ? options.progressTimeout : 1000);
-    self.fileNameReplacements = [[/"/g, ""], [/'/g, ""], [/\//g, ""], [/\?/g, ""], [/:/g, ""], [/;/g, ""]];
+    self.fileNameReplacements = [[/"/g, ""], [/\|/g, ""], [/'/g, ""], [/\//g, ""], [/\?/g, ""], [/:/g, ""], [/;/g, ""]];
     self.requestOptions = (options && options.requestOptions ? options.requestOptions : { maxRedirects: 5 });
     self.outputOptions = (options && options.outputOptions ? options.outputOptions : []);
 


### PR DESCRIPTION
Some youtubers add this character to separate parts of their video titles. This give invalid argument error on ffmpeg