### PR TITLE
Filter out WebM sources by default, since `ytdl.downloadFromInfo` misbehave when converting it to audio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ var YD = new YoutubeMp3Downloader({
     "outputPath": "/path/to/mp3/folder",    // Output file location (default: the home directory)
     "youtubeVideoQuality": "highestaudio",  // Desired video quality (default: highestaudio)
     "queueParallelism": 2,                  // Download parallelism (default: 1)
-    "progressTimeout": 2000                 // Interval in ms for the progress reports (default: 1000)
+    "progressTimeout": 2000,                // Interval in ms for the progress reports (default: 1000)
+    "allowWebm": false                      // Enable download from WebM sources (default: false)
 });
 
 //Download video and save as MP3 file

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ var YD = new YoutubeMp3Downloader({
     "outputPath": "/path/to/mp3/folder",    // Output file location (default: the home directory)
     "youtubeVideoQuality": "highestaudio",  // Desired video quality (default: highestaudio)
     "queueParallelism": 2,                  // Download parallelism (default: 1)
-    "progressTimeout": 2000                 // Interval in ms for the progress reports (default: 1000)
+    "progressTimeout": 2000,                // Interval in ms for the progress reports (default: 1000)
+    "allowWebm": false                      // Enable download from WebM sources 
 });
 
 //Download video and save as MP3 file

--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -19,6 +19,7 @@ class YoutubeMp3Downloader extends EventEmitter {
         this.fileNameReplacements = [[/'/g, ''], [/\|/g, ''], [/'/g, ''], [/\//g, ''], [/\?/g, ''], [/:/g, ''], [/;/g, '']];
         this.requestOptions = (options && options.requestOptions ? options.requestOptions : { maxRedirects: 5 });
         this.outputOptions = (options && options.outputOptions ? options.outputOptions : []);
+        this.allowWebm = (options && options.allowWebm ? options.allowWebm : false);
 
         if (options && options.ffmpegPath) {
             ffmpeg.setFfmpegPath(options.ffmpegPath);
@@ -96,10 +97,17 @@ class YoutubeMp3Downloader extends EventEmitter {
         const fileName = (task.fileName ? self.outputPath + '/' + task.fileName : self.outputPath + '/' + (sanitize(videoTitle) || info.videoId) + '.mp3');
 
         //Stream setup
-        const stream = ytdl.downloadFromInfo(info, {
+
+        const streamOptions =  {
             quality: self.youtubeVideoQuality,
             requestOptions: self.requestOptions
-        });
+        };
+
+        if (!self.allowWebm) {
+            streamOptions.filter = format => format.container === 'mp4';
+        }
+
+        const stream = ytdl.downloadFromInfo(info, streamOptions);
 
         stream.on('response', function(httpResponse) {
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,6 +6,7 @@ declare module YoutubeMp3Downloader {
     youtubeVideoQuality?: 'lowest' | 'highest' | string | number;
     queueParallelism: number;
     progressTimeout: number;
+    allowWebm?: boolean
   }
 
   export interface IResultObject {


### PR DESCRIPTION
Fixes https://github.com/ytb2mp3/youtube-mp3-downloader/issues/53;

It seems `ytdl.downloadFromInfo()` isn't accepting certain values for `quality` when the highest available quality is a webm, so for instance, trying to download this video `QjZwuimMb3M` with 'highestaudio' would cause an infinite load, due to the fact that the yielded stream won't trigger 'response' nor 'error';

