### PR TITLE
Fix null audioBitrate on some videos

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -137,11 +137,14 @@ class YoutubeMp3Downloader extends EventEmitter {
                 outputOptions = outputOptions.concat(self.outputOptions);
             }
             
+            const audioBitrate =
+                info.formats.find(format => !!format.audioBitrate).audioBitrate
+
             //Start encoding
             const proc = new ffmpeg({
                 source: stream.pipe(str)
             })
-            .audioBitrate(info.formats[0].audioBitrate)
+            .audioBitrate(audioBitrate)
             .withAudioCodec('libmp3lame')
             .toFormat('mp3')
             .outputOptions(...outputOptions)


### PR DESCRIPTION
This PR fixes the errors of the issue #67

The error was due to the fact that sometimes we had the `audioBitrate` being set as `null`

![audiobitratenull](https://user-images.githubusercontent.com/20830847/98714212-618a7680-2367-11eb-83df-c61fadde9530.JPG)

That value was get from the first element of the `formats` array. The solution was to simply search for a valid `audioBitrate` before setting it

```
const audioBitrate = info.formats.find(format => !!format.audioBitrate).audioBitrate

...

const proc = new ffmpeg({
    source: stream.pipe(str)
})
.audioBitrate(audioBitrate)
...
```