### PR TITLE
fix deprecation warning

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -86,7 +86,7 @@ class YoutubeMp3Downloader extends EventEmitter {
         var videoTitle = this.cleanFileName(info.videoDetails.title);
         var artist = 'Unknown';
         var title = 'Unknown';
-        var thumbnail = info.videoDetails.thumbnail.thumbnails[0].url || null;
+        var thumbnail = info.videoDetails.thumbnails[0].url || null;
     
         if (videoTitle.indexOf('-') > -1) {
             var temp = videoTitle.split('-');


### PR DESCRIPTION
Fixes deprecation warning:
```
`videoDetails.thumbnail.thumbnails` will be removed in a near future release, use `videoDetails.thumbnails` instead.`
```