### PR TITLE
requestOptions type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,7 +6,8 @@ declare module YoutubeMp3Downloader {
     youtubeVideoQuality?: 'lowest' | 'highest' | string | number;
     queueParallelism: number;
     progressTimeout: number;
-    allowWebm?: boolean
+    allowWebm?: boolean;
+    requestOptions?: {};
   }
 
   export interface IResultObject {


### PR DESCRIPTION
add request options to type definitions, since was not possible to use it using typescript

![image](https://user-images.githubusercontent.com/20830847/102945817-a55fb800-449d-11eb-9529-0d7e5b888c2a.png)


closes #71