### PR TITLE
Fix video-has-incorrect-content-length bug by manually calling stream.finished event if progress > 100.

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -136,6 +136,13 @@ class YoutubeMp3Downloader extends EventEmitter {
                         runtime: progress.runtime,
                         averageSpeed: parseFloat(progress.speed.toFixed(2))
                     }
+                } else if (progress.percentage > 100) {
+                    resultObj.stats= {
+                        transferredBytes: progress.transferred,
+                        runtime: progress.runtime,
+                        averageSpeed: parseFloat(progress.speed.toFixed(2))
+                    }
+                    return self.emit('finished', {videoId: task.videoId, progress: progress})
                 }
                 self.emit('progress', {videoId: task.videoId, progress: progress})
             });
@@ -180,3 +187,4 @@ class YoutubeMp3Downloader extends EventEmitter {
 }
 
 module.exports = YoutubeMp3Downloader;
+


### PR DESCRIPTION
See 