### PR TITLE
Fix #92

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -80,7 +80,7 @@ class YoutubeMp3Downloader extends EventEmitter {
          try {
             info = await ytdl.getInfo(videoUrl, { quality: this.youtubeVideoQuality })
          } catch (err){
-            callback(err);
+            return callback(err);
          }
     
         var videoTitle = this.cleanFileName(info.videoDetails.title);


### PR DESCRIPTION
The issue is similar to #72, if ytdl.getInfo() fails, the code execution should stop after calling the callback function.